### PR TITLE
Add to Graph control arrow directions which represent the direction of the link between two nodes

### DIFF
--- a/Demo/Wpf/Graph/GraphPage.xaml
+++ b/Demo/Wpf/Graph/GraphPage.xaml
@@ -90,8 +90,10 @@
                 </Style>
 
                 <DataTemplate x:Key="nodeTemplate" >
-                    <Button Background="{Binding Converter={StaticResource NodeColorConverter}}"
-                  Command="{x:Static local:GraphPage.ChangeCenter}" CommandParameter="{Binding }" Padding="10">
+                    <Button 
+                        lib:Graph.DirectionType="{Binding ArrowDirection}"
+                        Background="{Binding Converter={StaticResource NodeColorConverter}}"
+                        Command="{x:Static local:GraphPage.ChangeCenter}" CommandParameter="{Binding }" Padding="10">
                         <TextBlock Text="{Binding Path=Item}" FontSize="16" Name="textBlock"/>
                     </Button>
                     <DataTemplate.Triggers>

--- a/Demo/Wpf/Graph/NodeClasses.cs
+++ b/Demo/Wpf/Graph/NodeClasses.cs
@@ -21,6 +21,12 @@ namespace PixelLab.Wpf.Demo
 
             m_item = item;
             m_parent = parent;
+            m_arrowDirection = new Random().NextDouble() > 0.5 ? ArrowDirectionType.FromCenterToElement : ArrowDirectionType.FromElementToCenter;
+        }
+
+        public ArrowDirectionType ArrowDirection
+        {
+            get { return m_arrowDirection; }
         }
 
         public ReadOnlyObservableCollection<Node<T>> ChildNodes
@@ -75,6 +81,7 @@ namespace PixelLab.Wpf.Demo
 
         private readonly T m_item;
         private readonly NodeCollection<T> m_parent;
+        private readonly ArrowDirectionType m_arrowDirection;
     }
 
     public class NodeChildrenChangedArgs<T> : EventArgs


### PR DESCRIPTION
Hi,
After long time I finally manage to put our code into pull request.
In our application we use your graph control to allow navigation inside a network. Each node in the graph represent either a node or link in the network. Between nodes in the graph that represent link we like to present the direction of the link.
This is where AroowDirectionType come into play. Each ViewModel in our application know to answer the question "What is your direction relative to the center?".
In the demo application I simply randomize a value, but it's just for demo purposes.

If you think the code is not good enough, better naming or documentation please let me know.

Thank you,
Ido.
